### PR TITLE
Change acc3tiff to acc3tif

### DIFF
--- a/lfptools/prepdata.py
+++ b/lfptools/prepdata.py
@@ -236,7 +236,7 @@ def prepdata(argv):
             print("calculating area in extent...")
             calculate_area(dir3tau, are3tif)
 
-        if not acc_area and (not os.path.exists(acc3tiff) or overwrite):
+        if not acc_area and (not os.path.exists(acc3tif) or overwrite):
             print("getting flow accumulation in km2...")
             multiply_rasters(_acc3tif, are3tif, acc3tif)
 


### PR DESCRIPTION
Just a minor mistake, the `acc3tiff` does not exist in prepdata.py, instead it should be `acc3tif`.
I found it through this:
![fail](https://user-images.githubusercontent.com/62197564/115215079-b8c21d80-a135-11eb-8c64-a8e367fcc924.jpg)
